### PR TITLE
feat: platform-specific Docker Compose for OpenVINO and RK3588

### DIFF
--- a/docker-compose.openvino.yml
+++ b/docker-compose.openvino.yml
@@ -1,0 +1,102 @@
+# Platform: Intel OpenVINO — x86_64 with Intel CPU / iGPU / Arc GPU
+# Usage: docker compose -f docker-compose.openvino.yml up --build
+# Hardware: Intel Core/Xeon, integrated GPU (UHD/Iris/Arc), OpenVINO CPU plugin fallback
+#
+# Device mounts (/dev/dri) enable hardware-accelerated inference and video decode via VAAPI.
+# Remove the `devices` blocks if running on a machine without an Intel GPU.
+
+services:
+  frontend:
+    build:
+      context: ./frontend
+    ports:
+      - "3000:3000"
+    environment:
+      - INTERNAL_API_URL=http://nginx
+      - NEXT_PUBLIC_API_URL=http://localhost
+    volumes:
+      - frontend_node_modules:/app/node_modules
+    depends_on:
+      - backend
+    networks:
+      - retail-net
+
+  backend:
+    build:
+      context: ./backend
+    env_file:
+      - ./backend/.env
+    environment:
+      - VIDEO_PIPELINE_URL=http://video_pipeline:8002
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    networks:
+      - retail-net
+
+  db:
+    image: postgres:15.5
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-atriva}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-PassworD}
+      - POSTGRES_DB=${POSTGRES_DB:-atrv-retail}
+    env_file:
+      - ./backend/.env
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - retail-net
+
+  ai_inference:
+    build: ./services/ai-inference
+    ports:
+      - "8001:8001"
+    volumes:
+      - shared-temp-data:/app/shared
+    devices:
+      - /dev/dri:/dev/dri  # Intel GPU — OpenVINO GPU plugin + iGPU inference
+    extra_hosts:
+      - "localhost:host-gateway"
+    networks:
+      - retail-net
+
+  video_pipeline:
+    build: ./services/video-pipeline
+    ports:
+      - "8002:8002"
+    volumes:
+      - shared-temp-data:/app/shared
+    devices:
+      - /dev/dri:/dev/dri  # Intel VAAPI — hardware video decode/encode
+    extra_hosts:
+      - "localhost:host-gateway"
+    networks:
+      - retail-net
+
+  nginx:
+    image: nginx:1.25.3-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+    depends_on:
+      - frontend
+      - backend
+      - video_pipeline
+      - ai_inference
+    networks:
+      - retail-net
+
+volumes:
+  pgdata:
+  shared-temp-data:
+  frontend_node_modules:
+
+networks:
+  retail-net:
+    driver: bridge

--- a/docker-compose.rk3588.yml
+++ b/docker-compose.rk3588.yml
@@ -1,0 +1,126 @@
+# Platform: Rockchip RK3588 — ARM64 with RKNN NPU + Mali GPU
+# Usage: docker compose -f docker-compose.rk3588.yml up --build
+# Hardware: Orange Pi 5, Rock 5B, Radxa Zero 3, FriendlyElec CM3588, NanoPC-T6
+#
+# Prerequisites before building:
+#   services/ai-inference-rk3588/rknpu/ must contain:
+#     - librknnrt.so       (Rockchip RKNN runtime, from rknn-toolkit2 release)
+#     - rknn_server        (RKNN server binary, from rknn-toolkit2 release)
+#     - rknn_toolkit2-*.whl (Python wheel, from rknn-toolkit2 release)
+#     - start_rknn.sh / restart_rknn.sh
+#
+# Cross-build from x86 host: ensure Docker buildx with linux/arm64 support is enabled.
+#   docker buildx create --use
+#   docker buildx inspect --bootstrap
+
+services:
+  frontend:
+    build:
+      context: ./frontend
+      platform: linux/arm64
+    ports:
+      - "3000:3000"
+    environment:
+      - INTERNAL_API_URL=http://nginx
+      - NEXT_PUBLIC_API_URL=http://localhost
+    volumes:
+      - frontend_node_modules:/app/node_modules
+    depends_on:
+      - backend
+    networks:
+      - retail-net
+
+  backend:
+    build:
+      context: ./backend
+      platform: linux/arm64
+    env_file:
+      - ./backend/.env
+    environment:
+      - VIDEO_PIPELINE_URL=http://video_pipeline:8002
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    networks:
+      - retail-net
+
+  db:
+    image: postgres:15.5
+    platform: linux/arm64
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-atriva}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-PassworD}
+      - POSTGRES_DB=${POSTGRES_DB:-atrv-retail}
+    env_file:
+      - ./backend/.env
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - retail-net
+
+  ai_inference:
+    build:
+      context: ./services/ai-inference-rk3588
+      platform: linux/arm64
+    ports:
+      - "8001:8001"
+    volumes:
+      - shared-temp-data:/app/shared
+    devices:
+      - /dev/dri:/dev/dri              # Mali GPU
+      - /dev/dma_heap:/dev/dma_heap    # Zero-copy DMA buffer sharing (NPU ↔ CPU ↔ GPU)
+    group_add:
+      - video
+      - render
+    extra_hosts:
+      - "localhost:host-gateway"
+    networks:
+      - retail-net
+
+  video_pipeline:
+    build:
+      context: ./services/video-pipeline-ffmpeg-rk3588
+      platform: linux/arm64
+    ports:
+      - "8002:8002"
+    volumes:
+      - shared-temp-data:/app/shared
+    devices:
+      - /dev/dri:/dev/dri              # Mali GPU — jellyfin-ffmpeg hardware decode (rkmpp)
+      - /dev/dma_heap:/dev/dma_heap    # DMA buffer sharing
+    group_add:
+      - video
+      - render
+    extra_hosts:
+      - "localhost:host-gateway"
+    networks:
+      - retail-net
+
+  nginx:
+    image: nginx:1.25.3-alpine
+    platform: linux/arm64
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+    depends_on:
+      - frontend
+      - backend
+      - video_pipeline
+      - ai_inference
+    networks:
+      - retail-net
+
+volumes:
+  pgdata:
+  shared-temp-data:
+  frontend_node_modules:
+
+networks:
+  retail-net:
+    driver: bridge


### PR DESCRIPTION
## Summary

- Adds `docker-compose.openvino.yml` for Intel x86 deployments — wires `services/ai-inference` (OpenVINO pip package) and `services/video-pipeline` (Intel VAAPI/FFmpeg on Ubuntu 24.04); exposes `/dev/dri` for hardware-accelerated inference and video decode
- Adds `docker-compose.rk3588.yml` for ARM64/RK3588 deployments — wires `services/ai-inference-rk3588` (RKNN NPU) and `services/video-pipeline-ffmpeg-rk3588` (rkmpp via jellyfin-ffmpeg); exposes `/dev/dri`, `/dev/dma_heap`, and adds `video`/`render` group access for zero-copy DMA buffer sharing
- Also fixes `services/ai-inference-rk3588` Dockerfile: invalid `COPY ... 2>/dev/null || echo` shell syntax replaced with valid Docker `COPY` instructions (pushed directly to [atriva-ai/ai-inference-rk3588](https://github.com/atriva-ai/ai-inference-rk3588))

## Not in this PR

- Jetson/DeepStream wiring — deferred
- Submodule registration for rk3588 service repos — next step

## Test plan

- [ ] `docker compose -f docker-compose.openvino.yml up --build` on an Intel x86 host
- [ ] `docker compose -f docker-compose.rk3588.yml up --build` on RK3588 (native) or via `docker buildx` with `linux/arm64`
- [ ] Verify existing `docker compose up` (default `docker-compose.yml`) still builds cleanly for OpenVINO

🤖 Generated with [Claude Code](https://claude.com/claude-code)